### PR TITLE
Move "@types/luxon" to the "dependencies" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@types/fs-extra": "^9.0.13",
     "@types/globule": "^1.1.4",
     "@types/he": "^1.1.2",
-    "@types/luxon": "^2.0.8",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.2",
     "@types/progress": "^2.0.5",
@@ -108,6 +107,7 @@
     "xpath": "^0.0.32"
   },
   "dependencies": {
+    "@types/luxon": "^2.0.8",
     "batch-cluster": "^8.0.1",
     "he": "^1.2.0",
     "luxon": "^2.2.0",


### PR DESCRIPTION
The exiftool-vendored uses the luxon's DateTime type in public interfaces (for example, in ExifTime class). So, the @types/luxon should be in the "dependencies" section instead of "devDependencies". Otherwise, the TS code that uses exiftool-vendored and doesn't use luxon in its own dependencies, will not have access to the luxon's types.