### PR TITLE
update to 12.87 and add ContainerDirectory tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "luxon": "^3.4.4"
   },
   "optionalDependencies": {
-    "exiftool-vendored.exe": "12.85.0",
-    "exiftool-vendored.pl": "12.85.0"
+    "exiftool-vendored.exe": "12.87.0",
+    "exiftool-vendored.pl": "12.87.0"
   }
 }

--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -4649,6 +4649,8 @@ export interface XMPTags {
   Comment?: string
   /** ☆☆☆☆ ✔ Example: {"Directory":[{"Item":{"DataURI":"primary_image","Length"…eg"}}]} */
   Container?: Struct
+  /** ☆☆☆☆ ✔ Example: [{"Item":{"Mime":"image/jpeg","Semantic":"Primary"}},…] */
+  ContainerDirectory?: { Item: { Length?: number; Mime: string; Padding?: number; Semantic?: string; } }[]
   /** ☆☆☆☆ ✔ Example: false */
   ConvertToGrayscale?: boolean
   /** ☆☆☆☆ ✔ Example: "United States" */


### PR DESCRIPTION
## Context

https://github.com/immich-app/immich/issues/10374

## Why

exiftool 12.85 changed the priority of the Directory tag extraction, so it never returns structured data.

In 12.87 the structured data is available as `ContainerDirectory`.

```js
import { ExifTool } from 'exiftool-vendored';

const exiftool = new ExifTool({ exiftoolPath: '/Image-ExifTool-12.87/exiftool' });

const tags = await exiftool.read('/PXL_20240413_112841935.MP.jpg', {
  readArgs: ['-struct'],
});

console.log(tags.ContainerDirectory);
/*
[
  { Item: { Mime: 'image/jpeg', Semantic: 'Primary' } },
  { Item: { Length: 59107, Mime: 'image/jpeg', Semantic: 'GainMap' } },
  {
    Item: {
      Length: 3127491,
      Mime: 'video/mp4',
      Padding: 0,
      Semantic: 'MotionPhoto'
    }
  }
]
*/
```

## TODO

- [ ] update exiftool-vendored.pl and exe to 12.87
- [ ] maybe remove the `Container` tag because that seems to be the same judging by the example