### PR TITLE
Make inferLikelyOffsetMinutes pick the closest real timezone

### DIFF
--- a/src/Timezones.spec.ts
+++ b/src/Timezones.spec.ts
@@ -161,6 +161,17 @@ describe("Timezones", () => {
   })
 
   describe("extractTzOffsetFromUTCOffset", () => {
+    it("with DateTimeUTC offset by 4 hours and lagging by one second from DateTimeOriginal", () => {
+      expect(
+        extractTzOffsetFromUTCOffset({
+          DateTimeOriginal: "2024:09:14 12:00:00",
+          DateTimeUTC: "2024:09:14 16:00:01",
+        })
+      ).to.eql({
+        tz: "UTC-4",
+        src: "offset between DateTimeOriginal and DateTimeUTC",
+      })
+    })
     it("with lagging GPSDateStamp & GPSTimeStamp and DateTimeOriginal in negative offset", () => {
       expect(
         extractTzOffsetFromUTCOffset({

--- a/src/Timezones.ts
+++ b/src/Timezones.ts
@@ -409,11 +409,20 @@ export function extractTzOffsetFromDatestamps(
 // old, this can be spurious. We get less mistakes with a larger multiple, so
 // we're using 30 minutes instead of 15. See
 // https://www.timeanddate.com/time/time-zones-interesting.html
-
-const TzBoundaryMinutes = 30
+const LikelyOffsetMinutes = ValidTimezoneOffsets
+    .filter((offset) => offset.endsWith(":00") || offset.endsWith(":30"))
+    .map(offsetToMinutes)
 
 export function inferLikelyOffsetMinutes(deltaMinutes: number): number {
-  return TzBoundaryMinutes * Math.floor(deltaMinutes / TzBoundaryMinutes)
+  // More then a day away? nothing is likely
+  if (Math.abs(deltaMinutes) > (24 * 60)) return deltaMinutes
+
+  return LikelyOffsetMinutes
+    .reduce((prev, curr) =>
+      Math.abs(curr - deltaMinutes) < Math.abs(prev - deltaMinutes)
+      ? curr
+      : prev
+    )
 }
 
 /**


### PR DESCRIPTION
Offsets that are a little "under" a timezone will get `Math.floor`'d by `inferLikelyOffsetMinutes` to a, frankly unlikely, offset.

For instance my camera, being in America/New_York, would log the EDT time as `DateTimeOriginal` ("12:00:00") and then one second later record the UTC time as `DateTimeUTC` ("16:00:01"). This offset would be -240.01666666666668 minutes which with the current implementation of `inferLikelyOffsetMinutes` would result in the offset UTC-4.5 being chosen.

I was tempted to replace the `Math.floor` with `Math.round`, but that would also pick invalid timezone offsets occasionally (when the half hour timezone offset does not exist, which the `"with lagging GPSDateStamp & GPSTimeStamp and DateTimeOriginal in negative offset"` test case helpfully pointed out).

Instead I went with a probably slower, but more technically accurate, "find the closest" offset from the already existing `ValidTimezoneOffsets` array (but still throwing out the non-half-hour timezone offsets as "unlikely").