### PR TITLE
feat: add `forceWrite` option for tag extraction

### DIFF
--- a/src/BinaryExtractionTask.ts
+++ b/src/BinaryExtractionTask.ts
@@ -1,8 +1,11 @@
 import path from "node:path"
-import { ExifToolTask, ExifToolTaskOptions } from "./ExifToolTask"
+import { ExifToolTask } from "./ExifToolTask"
 import { Utf8FilenameCharsetArgs } from "./FilenameCharsetArgs"
 import { Maybe } from "./Maybe"
 import { toS } from "./String"
+import { ExifToolOptions } from "./ExifToolOptions"
+
+export type ExifToolBinaryExtractionTaskOptions = Pick<ExifToolOptions, "ignoreMinorErrors"> & Partial<Pick<ExifToolOptions, 'forceWrite'>>
 
 const StdoutRe = /\b(\d+) output files? created/i
 
@@ -11,7 +14,7 @@ const StdoutRe = /\b(\d+) output files? created/i
  * everything seems to have worked.
  */
 export class BinaryExtractionTask extends ExifToolTask<Maybe<string>> {
-  private constructor(args: string[], options?: ExifToolTaskOptions) {
+  private constructor(args: string[], options?: ExifToolBinaryExtractionTaskOptions) {
     super(args, options)
   }
 
@@ -19,13 +22,13 @@ export class BinaryExtractionTask extends ExifToolTask<Maybe<string>> {
     tagname: string,
     imgSrc: string,
     imgDest: string,
-    options?: ExifToolTaskOptions
+    options?: ExifToolBinaryExtractionTaskOptions
   ): BinaryExtractionTask {
     const args = [
       ...Utf8FilenameCharsetArgs,
       "-b",
       "-" + tagname,
-      "-w",
+      options?.forceWrite ? "-w!" : "-w",
       // The %0f prevents shell escaping. See
       // https://exiftool.org/exiftool_pod.html#w-EXT-or-FMT--textOut
       "%0f" + path.resolve(imgDest),

--- a/src/DefaultExifToolOptions.ts
+++ b/src/DefaultExifToolOptions.ts
@@ -61,6 +61,7 @@ export const DefaultExifToolOptions: Omit<
   geolocation: false,
   ignoreZeroZeroLatLon: true,
   ignoreMinorErrors: true,
+  forceWrite: false,
   imageHashType: false,
   includeImageDataMD5: undefined,
   inferTimezoneFromDatestamps: false, // to retain prior behavior

--- a/src/ExifTool.ts
+++ b/src/ExifTool.ts
@@ -4,7 +4,7 @@ import * as _fs from "node:fs"
 import process from "node:process"
 import { ifArr } from "./Array"
 import { retryOnReject } from "./AsyncRetry"
-import { BinaryExtractionTask } from "./BinaryExtractionTask"
+import { BinaryExtractionTask, ExifToolBinaryExtractionTaskOptions } from "./BinaryExtractionTask"
 import { BinaryToBufferTask } from "./BinaryToBufferTask"
 import { ContainerDirectoryItem } from "./ContainerDirectoryItem"
 import { DefaultExifToolOptions } from "./DefaultExifToolOptions"
@@ -543,7 +543,7 @@ export class ExifTool {
     tagname: string,
     src: string,
     dest: string,
-    opts?: ExifToolTaskOptions
+    opts?: ExifToolBinaryExtractionTaskOptions
   ): Promise<void> {
     // BinaryExtractionTask returns a stringified error if the output indicates
     // the task should not be retried.

--- a/src/ExifToolOptions.ts
+++ b/src/ExifToolOptions.ts
@@ -248,6 +248,15 @@ const exiftool = new ExifTool({ geoTz: (lat, lon) => geotz.find(lat, lon)[0] })
   ignoreMinorErrors: boolean
 
   /**
+   * When writing an extracted tag to a file,
+   * this will overwrite an existing file instead of throwing an error.
+   * Enabling this option is equivalent to `-w!` in ExifTool.
+   *
+   * This defaults to `false`.
+   */
+  forceWrite: boolean
+
+  /**
    * `ExifTool` has a shebang line that assumes a valid `perl` is installed at
    * `/usr/bin/perl`.
    *


### PR DESCRIPTION
### Description

The current behavior for tag extraction is to fail when the destination path already has a file. This PR adds an option to change the `-w` setting to `-w!` so exiftool overwrites it instead. I made this an optional flag to preserve current behavior, but it does make things more complicated than just changing it to always use `-w!`.

Note: I was unable to test this locally because I got CJS-related errors. I'm hoping the GitHub checks can handle this part 😄